### PR TITLE
Reuse existing profile

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = firefox-hg
 	pkgdesc = Standalone web browser from mozilla.org - mozilla-unified hg, nightly branding, targeting wayland and x11
-	pkgver = 123.0a1+20231230.1+h9660032084db
+	pkgver = 123.0a1+20240113.1+h23a77d3c25d7
 	pkgrel = 1
 	url = https://www.mozilla.org/firefox/channel/#nightly
 	arch = x86_64

--- a/upload-symbol-archive
+++ b/upload-symbol-archive
@@ -12,7 +12,7 @@ shift
 [[ -f $token && -s $token ]] || die "Invalid TOKEN-FILE ${token@Q}"
 
 for archive; do
-  [[ $(file -Ebi "$archive") == application/zstd* ]] || die "Invalid SYMBOL-ARCHIVE ${archive@Q}"
+  [[ $(file -Ebi "$archive") == application/zip* ]] || die "Invalid SYMBOL-ARCHIVE ${archive@Q}"
 done
 
 for archive; do
@@ -21,5 +21,4 @@ for archive; do
     --retry 4 --retry-connrefused --connect-timeout 120 \
     https://symbols.mozilla.org/upload/
   echo
-  mv -v "$archive" "$archive.uploaded"
 done


### PR DESCRIPTION
This PR adds ability to reuse existing profiles for PGO. This should retain the performance benefit of PGO while reducing resource use during rebuilds. Profiles need to be regenerated occasionally.

Problems with symbol uploads are also fixed.