### PR TITLE
Fix profiling, update options

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = firefox-hg
 	pkgdesc = Standalone web browser from mozilla.org - mozilla-unified hg, nightly branding, targeting wayland and x11
-	pkgver = 124.0a1+20240202.1+h36c0f999f668
+	pkgver = 125.0a1+20240220.1+hef9cbc0f26f8
 	pkgrel = 1
 	url = https://www.mozilla.org/firefox/channel/#nightly
 	arch = x86_64


### PR DESCRIPTION
Changes in this PR:

* Fix PGO profiling by adding `XDG_RUNTIME_DIR` and `LIBGL_ALWAYS_SOFTWARE`.
    * `MOZ_ENABLE_FULL_SYMBOLS=1` also seems to be needed for PGO profiling to succeed.
* Add option `_build_pgo_xvfb` to switch to `xvfb-run`, in case there are problems with `xwayland-run`.
* Add `mozconfig` options.  Most should have already been enabled/disabled by default.

Test build: [firefox-wayland-hg](https://builds.garudalinux.org/logs/logs.html?timestamp=1708401669554&id=firefox-wayland-hg)
